### PR TITLE
Migrate to rust errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,5 @@ colored = "2.1.0"
 shell-words = "1.1.0"
 reqwest = { version = "0.11.24", features = ["blocking"] }
 diesel = { version = "2.1", features = ["sqlite"] }
-
-# Used for unit testing
-rand = "0.8.5"
 linked-hash-map = "0.5.6"
+thiserror = "1.0.57"

--- a/src/action.rs
+++ b/src/action.rs
@@ -4,6 +4,9 @@ use std::{fmt::Display, process::Command};
 use crate::db::PackagesDb;
 use crate::package::{LocalPackage, RemotePackage};
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Action {
     Install(RemotePackage),

--- a/src/action/tests.rs
+++ b/src/action/tests.rs
@@ -4,9 +4,7 @@ use super::*;
 
 use crate::package::{PackageData, RemotePackage};
 
-use mock_db::MockPackagesDb;
-
-mod mock_db;
+use crate::test_helpers::MockPackagesDb;
 
 #[test]
 fn test_package_installs() {
@@ -30,16 +28,14 @@ fn test_package_removes() {
 
     let package_name = remote_package.package_data.name.clone();
 
-    mock_db
-        .add_package(&remote_package)
-        .expect("Could not add package to mock db");
+    mock_db.add_package(&remote_package).unwrap();
 
-    let local_package = mock_db.get_package(&package_name).unwrap();
+    let local_package = mock_db.get_package(&package_name).unwrap().unwrap();
 
     let action = Action::Remove(local_package);
 
     assert!(action.commit(&mut mock_db).is_ok());
-    assert!(mock_db.get_package(&package_name).is_err());
+    assert!(mock_db.get_package(&package_name).unwrap().is_none());
 }
 
 fn get_mock_remote_package() -> RemotePackage {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,9 +1,12 @@
+use std::fmt::Display;
+
 use log::{debug, info, trace};
 
 use crate::action::Action;
 use crate::db::PackagesDb;
-
 use crate::package::RemotePackage;
+
+pub use errors::*;
 
 use linked_hash_map::LinkedHashMap;
 
@@ -11,82 +14,88 @@ use linked_hash_map::LinkedHashMap;
 /// in the same order items where inserted.
 type LinkedHashSet<T> = LinkedHashMap<T, ()>;
 
+pub mod errors;
 #[cfg(test)]
 mod tests;
 
 pub trait PackageFinder {
-    fn find_package(&self, package_name: &str) -> Result<RemotePackage, String>;
+    type Error: Display;
+    fn find_package(&self, package_name: &str) -> Result<Option<RemotePackage>, Self::Error>;
 }
 
-pub fn install_packages(
+pub fn install_packages<EFind: Display, EDatabase: Display>(
     packages: Vec<String>,
-    package_finder: &dyn PackageFinder,
+    package_finder: &impl PackageFinder<Error = EFind>,
     reinstall: bool,
-    db: &mut impl PackagesDb,
-) -> Result<Vec<Action>, String> {
+    db: &mut impl PackagesDb<GetError = EDatabase>,
+) -> Result<Vec<Action>, InstallError<EDatabase, EFind>> {
     let mut actions: LinkedHashSet<Action> = LinkedHashSet::new();
 
     for package_name in packages.iter() {
-        match install_package(package_name, package_finder, reinstall, db) {
-            Ok(new_actions) => actions.extend(new_actions),
-            Err(error) => {
-                return Err(format!(
-                    "Could not genereate actions for package {package_name}:\n{error}"
-                ))
-            }
-        }
+        actions.extend(install_package(
+            package_name,
+            package_finder,
+            reinstall,
+            db,
+        )?);
     }
 
     Ok(actions.keys().cloned().collect())
 }
 
-pub fn remove_packages(
+pub fn remove_packages<EDatabase: Display>(
     package_names: Vec<String>,
     recursive: bool,
-    db: &mut impl PackagesDb,
-) -> Result<Vec<Action>, String> {
+    db: &mut impl PackagesDb<GetError = EDatabase>,
+) -> Result<Vec<Action>, RemoveError<EDatabase>> {
     let mut actions: LinkedHashSet<Action> = LinkedHashSet::new();
 
     for package_name in package_names.into_iter() {
-        match remove_package(&package_name, recursive, db) {
-            Ok(new_actions) => actions.extend(new_actions),
-            Err(error) => {
-                return Err(format!(
-                    "Could not generate actions for package {package_name}:\n{error}"
-                ))
-            }
-        }
+        actions.extend(remove_package(&package_name, recursive, db)?);
     }
 
     Ok(actions.keys().cloned().collect())
 }
 
-fn install_package(
+fn install_package<EFind: Display, EDatabase: Display>(
     package_name: &str,
-    package_finder: &dyn PackageFinder,
+    package_finder: &impl PackageFinder<Error = EFind>,
     reinstall: bool,
-    db: &mut impl PackagesDb,
-) -> Result<LinkedHashSet<Action>, String> {
+    db: &mut impl PackagesDb<GetError = EDatabase>,
+) -> Result<LinkedHashSet<Action>, InstallError<EDatabase, EFind>> {
     let mut actions: LinkedHashSet<Action> = LinkedHashSet::new();
-
     trace!("Generating install actions for package: {package_name}");
 
-    if let Ok(local_package) = db.get_package(package_name) {
-        if reinstall {
-            info!("Package {package_name} already installed, reinstalling...");
-            // It's also possible to call remove_package and get the packge removal specific actions.
-            // But this can cause issues.
-            // - First a pointless database query for existance of the packge which is already guaranteed.
-            // - Second, all the recursive removal related issues. We reinstall a package and there's no need to check for dependency
-            // break as we will be installing it back again.
-            actions.insert(Action::Remove(local_package), ());
-        } else {
-            info!("Package {package_name} already installed. Ignoring...");
-            return Ok(actions);
+    match db.get_package(package_name) {
+        Ok(package) => {
+            if let Some(package) = package {
+                if reinstall {
+                    info!("Package {package_name} already installed, reinstalling...");
+                    // It's also possible to call remove_package and get the packge removal specific actions.
+                    // But this can cause issues.
+                    // - First a pointless database query for existance of the packge which is already guaranteed.
+                    // - Second, all the recursive removal related issues. We reinstall a package and there's no need to check for dependency
+                    // break as we will be installing it back again.
+                    actions.insert(Action::Remove(package), ());
+                } else {
+                    info!("Package {package_name} already installed. Ignoring...");
+                    return Ok(actions);
+                }
+            }
         }
+        Err(error) => return Err(InstallError::Database(error)),
     }
 
-    let package = package_finder.find_package(package_name)?;
+    let package = match package_finder.find_package(package_name) {
+        Ok(package) => package,
+        Err(error) => return Err(InstallError::Find(error)),
+    };
+
+    if package.is_none() {
+        return Err(InstallError::PackageNotFound(String::from(package_name)));
+    }
+
+    let package = package.unwrap();
 
     trace!("Found remote package:\n{package:#?}");
     for dependency in package.dependencies.iter() {
@@ -98,41 +107,52 @@ fn install_package(
     Ok(actions)
 }
 
-fn remove_package(
+fn remove_package<EDatabase: Display>(
     package_name: &str,
     recursive: bool,
-    db: &mut impl PackagesDb,
-) -> Result<LinkedHashSet<Action>, String> {
+    db: &mut impl PackagesDb<GetError = EDatabase>,
+) -> Result<LinkedHashSet<Action>, RemoveError<EDatabase>> {
     let mut actions: LinkedHashSet<Action> = LinkedHashSet::new();
 
     debug!("Searching initial package {package_name}");
 
     let db_package = match db.get_package(package_name) {
-        Ok(package) => package,
-        Err(error) => return Err(format!("Could not get package from db:\n{error}")),
+        Ok(package) => {
+            if package.is_none() {
+                return Err(RemoveError::PackageNotInstalled(String::from(package_name)));
+            }
+            package.unwrap()
+        }
+        Err(error) => return Err(RemoveError::DatabaseGet(error)),
     };
 
-    if let Ok(depending_packages) = db.get_depending_packages(package_name) {
-        if !depending_packages.is_empty() {
-            if recursive {
-                info!("Found depending packages, uninstalling...");
-                for dependency in depending_packages.iter() {
-                    actions.extend(remove_package(
-                        &dependency.package_data.name,
-                        recursive,
-                        db,
-                    )?);
-                }
-            } else {
-                let depending_packages: Vec<String> = depending_packages
-                    .into_iter()
-                    .map(|p| p.package_data.name)
-                    .collect();
+    match db.get_depending_packages(package_name) {
+        Ok(depending_packages) => {
+            if !depending_packages.is_empty() {
+                if recursive {
+                    info!("Found depending packages, uninstalling...");
+                    for dependency in depending_packages.iter() {
+                        actions.extend(remove_package(
+                            &dependency.package_data.name,
+                            recursive,
+                            db,
+                        )?);
+                    }
+                } else {
+                    let depending_packages: Vec<String> = depending_packages
+                        .into_iter()
+                        .map(|p| p.package_data.name)
+                        .collect();
 
-                return Err(format!(
-                    "Removing package breaks dependencies: {depending_packages:?}. "
-                ));
+                    return Err(RemoveError::DependencyBreak(
+                        String::from(package_name),
+                        depending_packages,
+                    ));
+                }
             }
+        }
+        Err(error) => {
+            return Err(RemoveError::DatabaseGet(error));
         }
     }
 

--- a/src/commands/errors.rs
+++ b/src/commands/errors.rs
@@ -1,0 +1,22 @@
+use std::fmt::Display;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum InstallError<EDatabase: Display, EFind: Display> {
+    #[error("Package {0} not found.")]
+    PackageNotFound(String),
+    #[error("Error while searching for package {0}")]
+    Find(EFind),
+    #[error("A database error has occured {0}")]
+    Database(EDatabase),
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum RemoveError<EDatabase: Display> {
+    #[error("Package {0} not installed.")]
+    PackageNotInstalled(String),
+    #[error("Removing package {0} breaks dependencies {1:?}.")]
+    DependencyBreak(String, Vec<String>),
+    #[error("Could not get package from databae: {0}")]
+    DatabaseGet(EDatabase),
+}

--- a/src/commands/tests/mock_package_finder.rs
+++ b/src/commands/tests/mock_package_finder.rs
@@ -4,34 +4,38 @@ use crate::commands::PackageFinder;
 
 pub struct MockPackageFinder;
 impl PackageFinder for MockPackageFinder {
-    fn find_package(&self, package_name: &str) -> Result<RemotePackage, String> {
+    type Error = String;
+
+    fn find_package(&self, package_name: &str) -> Result<Option<RemotePackage>, String> {
         Ok(match package_name {
-            "simple_package" => RemotePackage {
+            "simple_package" => Some(RemotePackage {
                 package_data: PackageData {
                     name: String::from("simple_package"),
                     ..Default::default()
                 },
                 ..Default::default()
-            },
-            "package_with_dependency" => RemotePackage {
+            }),
+            "package_with_dependency" => Some(RemotePackage {
                 package_data: PackageData {
                     name: String::from("package_with_dependency"),
                     ..Default::default()
                 },
                 dependencies: vec![String::from("simple_package")],
                 ..Default::default()
-            },
-            _ => panic!("Unexpected package {package_name}"),
+            }),
+            _ => None,
         })
     }
 }
 
 impl MockPackageFinder {
     pub fn get_simple_packge(&self) -> RemotePackage {
-        self.find_package("simple_package").unwrap()
+        self.find_package("simple_package").unwrap().unwrap()
     }
 
     pub fn get_package_with_dependency(&self) -> RemotePackage {
-        self.find_package("package_with_dependency").unwrap()
+        self.find_package("package_with_dependency")
+            .unwrap()
+            .unwrap()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::fmt;
-use std::fmt::Display;
 use std::fs;
 use std::io;
 use std::path::Path;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,12 @@
 use serde_json::Value as JsonValue;
 
-use std::{collections::HashMap, fs, path::Path};
-use std::io;
+use std::fs;
+use std::collections::HashMap;
+use std::path::Path;
+use std::io::{self};
 use std::fmt::{self, Display};
 
-use log::{info, trace};
+use log::trace;
 
 #[cfg(test)]
 mod tests;
@@ -48,27 +50,27 @@ impl From<serde_json::Error> for Error {
 
 
 impl Config {
-    pub fn create_default_config_if_necessary(config_path: &str) -> Result<(), io::Error> {
-        trace!("Creating defalt configs if necessary");
+    pub fn create_default_config_if_necessary(config_path: &str) -> Result<bool, io::Error> {
+        trace!("Creating default configs if necessary");
 
         let config_path = Path::new(config_path);
 
         match config_path.try_exists()? {
-            true => Ok(()),
+            true => Ok(false),
             false => {
-                info!("Config file does not exist. Creating new...");
-
-                trace!("Creating config parent directories.");
-
+                trace!("Creating config file parent directories.");
                 fs::create_dir_all(config_path.parent().unwrap())?;
 
-                trace!("Creating and writing to config file.");
+                trace!("Creating config file.");
+                fs::File::create(config_path)?;
 
-                fs::write(config_path, DEFAULT_CONFIG)?;
-
-                Ok(())
+                Ok(true)
             }
         }
+    }
+
+    pub fn write_default_config(config_path: &str) -> Result<(), io::Error> {
+        fs::write(config_path, DEFAULT_CONFIG)
     }
 
     pub fn from_file(config_path: &str) -> Result<Config, Error> {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -4,9 +4,15 @@ const CONFIG_PATH: &str = "/tmp/japm/tests/config.json";
 
 #[test]
 fn test_default_config_created_properly() {
+    if fs::metadata(CONFIG_PATH).is_ok() {
+        fs::remove_file(CONFIG_PATH).expect("Could not remove test file");
+    }
+
     assert!(Config::create_default_config_if_necessary(CONFIG_PATH).is_ok());
 
     assert!(fs::metadata(CONFIG_PATH).is_ok());
+
+    assert!(Config::write_default_config(CONFIG_PATH).is_ok());
 
     let config = Config::from_file(CONFIG_PATH);
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -32,9 +32,10 @@ fn test_config_parsed_correctly() {
 }
 "#;
 
-    let config = Config::from_json(&config).unwrap();
+    let config = Config::from_json(&config);
+    assert!(config.is_ok());
 
-    assert_eq!(config.remotes.get("test").unwrap(), "http://test.com")
+    assert_eq!(config.unwrap().remotes.get("test").unwrap(), "http://test.com")
 }
 
 #[test]
@@ -51,6 +52,7 @@ this is invalid json syntax
     let config = Config::from_json(&config);
 
     assert!(config.is_err());
+    assert!(matches!(config, Err(Error::Json(_))));
 }
 
 #[test]
@@ -60,21 +62,23 @@ fn test_no_remotes_field_rejected() {
     let config = Config::from_json(&config);
 
     assert!(config.is_err());
+    assert!(matches!(config, Err(Error::Syntax(_))));
 }
 
 #[test]
 fn test_non_string_remotes_rejected() {
     let config = r#"
 {
-    "remotes": [
-        "test": {
+    "remotes": {
+        "key with non strign value": {
             "some_non_string_object": "http://test.com"
         }
-    ]
+    }
 }
 "#;
 
     let config = Config::from_json(&config);
 
     assert!(config.is_err());
+    assert!(matches!(config, Err(Error::Syntax(_))));
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,26 +1,34 @@
+use std::fmt::Display;
 use std::fs::{self, File};
-use std::path::Path;
 use std::io;
-use std::fmt::{self, Display};
+use std::path::Path;
 
-use log::{trace, info};
+use log::{info, trace};
 
 use crate::package::{LocalPackage, PackageData, RemotePackage};
 
 use diesel::prelude::*;
 
+pub use errors::*;
+
 // diesel has questionable naming
-use diesel::result::{
-    Error as QueryError,
-    ConnectionError
-};
+use diesel::result::{ConnectionError, Error as QueryError};
+
+mod errors;
 
 pub trait PackagesDb {
-    fn add_package(&mut self, package: &RemotePackage) -> Result<(), String>;
-    fn remove_package(&mut self, package_name: &str) -> Result<(), String>;
-    fn get_package(&mut self, package_name: &str) -> Result<LocalPackage, String>;
-    fn get_all_packages(&mut self) -> Result<Vec<LocalPackage>, String>;
-    fn get_depending_packages(&mut self, package_name: &str) -> Result<Vec<LocalPackage>, String>;
+    type AddError: Display;
+    type RemoveError: Display;
+    type GetError: Display;
+
+    fn add_package(&mut self, package: &RemotePackage) -> Result<(), Self::AddError>;
+    fn remove_package(&mut self, package_name: &str) -> Result<(), Self::RemoveError>;
+    fn get_package(&mut self, package_name: &str) -> Result<Option<LocalPackage>, Self::GetError>;
+    fn get_all_packages(&mut self) -> Result<Vec<LocalPackage>, Self::GetError>;
+    fn get_depending_packages(
+        &mut self,
+        package_name: &str,
+    ) -> Result<Vec<LocalPackage>, Self::GetError>;
 }
 
 pub struct SqlitePackagesDb {
@@ -66,6 +74,7 @@ struct GetPackage {
     dependencies: String,
 }
 
+const DATABASE_SOURCE: &str = "/var/lib/japm/packages.db";
 impl SqlitePackagesDb {
     pub fn new() -> Result<SqlitePackagesDb, ConnectionError> {
         let mut url = String::from("sqlite://");
@@ -118,94 +127,72 @@ impl SqlitePackagesDb {
     }
 }
 
-const DATABASE_SOURCE: &str = "/var/lib/japm/packages.db";
 impl PackagesDb for SqlitePackagesDb {
-    fn add_package(&mut self, package: &RemotePackage) -> Result<(), String> {
+    type AddError = TranslatedPackageQueryError;
+    type GetError = TranslatedPackageQueryError;
+    type RemoveError = QueryError;
+
+    fn add_package(&mut self, package: &RemotePackage) -> Result<(), TranslatedPackageQueryError> {
         use self::packages::dsl::*;
 
         let db_package: AddPackage = package.try_into()?;
 
         trace!("Inserting {db_package:#?} into the database");
 
-        if let Err(error) = diesel::insert_into(packages)
+        diesel::insert_into(packages)
             .values(db_package)
-            .execute(&mut self.connection)
-        {
-            return Err(format!("Could not insert package to database:\n{error}"));
-        }
+            .execute(&mut self.connection)?;
+
         Ok(())
     }
 
-    fn remove_package(&mut self, package_name: &str) -> Result<(), String> {
+    fn remove_package(&mut self, package_name: &str) -> Result<(), QueryError> {
         use self::packages::dsl::*;
 
-        if let Err(error) =
-            diesel::delete(packages.filter(name.eq(package_name))).execute(&mut self.connection)
-        {
-            return Err(format!("Error while running remove query:\n{error}"));
-        }
+        diesel::delete(packages.filter(name.eq(package_name))).execute(&mut self.connection)?;
 
         Ok(())
     }
 
-    fn get_package(&mut self, package_name: &str) -> Result<LocalPackage, String> {
+    fn get_package(
+        &mut self,
+        package_name: &str,
+    ) -> Result<Option<LocalPackage>, TranslatedPackageQueryError> {
         use self::packages::dsl::*;
 
         match packages
             .filter(name.eq(package_name))
             .first::<GetPackage>(&mut self.connection)
+            .optional()?
         {
-            Ok(package) => match <GetPackage as TryInto<LocalPackage>>::try_into(package) {
-                Ok(package) => Ok(package),
-                Err(error) => Err(format!(
-                    "Could not convert query type into package type:\n{error}"
-                )),
-            },
-            Err(error) => {
-                if error == diesel::NotFound {
-                    Err(String::from("No such package"))
-                } else {
-                    Err(format!("Error attempting to retrieve package:\n{error}"))
-                }
-            }
+            Some(package) => Ok(Some(<GetPackage as TryInto<LocalPackage>>::try_into(
+                package,
+            )?)),
+            None => Ok(None),
         }
     }
 
-    fn get_all_packages(&mut self) -> Result<Vec<LocalPackage>, String> {
+    fn get_all_packages(&mut self) -> Result<Vec<LocalPackage>, TranslatedPackageQueryError> {
         use self::packages::dsl::*;
 
-        match packages
+        let all_packages = packages
             .select(packages::all_columns())
-            .load::<GetPackage>(&mut self.connection)
-        {
-            Ok(all_packages) => {
-                let convert_into = |item: GetPackage| -> Result<LocalPackage, String> {
-                    let package_name = item.name.clone();
-                    match item.try_into() {
-                        Ok(package) => Ok(package),
-                        // If there's an error we can print the specific package it happened to.
-                        Err(error) => Err(format!(
-                            "Could not convert query package {} into package:\n{}",
-                            package_name, error
-                        )),
-                    }
-                };
+            .load::<GetPackage>(&mut self.connection)?;
 
-                let all_packages: Result<Vec<LocalPackage>, String> =
-                    all_packages.into_iter().map(convert_into).collect();
-
-                match all_packages {
-                    Ok(all_packages) => Ok(all_packages),
-                    Err(error) => Err(format!(
-                        "Could not map all query types to package type:\n{error}"
-                    )),
-                }
+        let convert_into = |item: GetPackage| -> Result<LocalPackage, TranslatedPackageQueryError> {
+            match item.try_into() {
+                Ok(package) => Ok(package),
+                Err(error) => Err(TranslatedPackageQueryError::Json(error)),
             }
-            Err(error) => Err(format!("Could not get all packages:\n{error}")),
-        }
+        };
+
+        all_packages.into_iter().map(convert_into).collect()
     }
 
-    fn get_depending_packages(&mut self, package_name: &str) -> Result<Vec<LocalPackage>, String> {
+    fn get_depending_packages(
+        &mut self,
+        package_name: &str,
+    ) -> Result<Vec<LocalPackage>, TranslatedPackageQueryError> {
         let all_packages = self.get_all_packages()?;
         let mut depending_packages: Vec<LocalPackage> = Vec::new();
 
@@ -222,35 +209,21 @@ impl PackagesDb for SqlitePackagesDb {
 }
 
 impl TryFrom<&RemotePackage> for AddPackage {
-    type Error = String;
+    type Error = serde_json::Error;
 
     fn try_from(package: &RemotePackage) -> Result<Self, Self::Error> {
         Ok(AddPackage {
             name: package.package_data.name.clone(),
             version: package.package_data.version.clone(),
             description: package.package_data.description.clone(),
-            remove_instructions: match serde_json::to_string(&package.remove) {
-                Ok(string) => string,
-                Err(error) => {
-                    return Err(format!(
-                        "Could not convert package's install instructions to json:\n{error}"
-                    ))
-                }
-            },
-            dependencies: match serde_json::to_string(&package.dependencies) {
-                Ok(string) => string,
-                Err(error) => {
-                    return Err(format!(
-                        "Could not convert the package's dependencies to json:\n{error}"
-                    ))
-                }
-            },
+            remove_instructions: serde_json::to_string(&package.remove)?,
+            dependencies: serde_json::to_string(&package.dependencies)?,
         })
     }
 }
 
 impl TryInto<LocalPackage> for GetPackage {
-    type Error = String;
+    type Error = serde_json::Error;
 
     fn try_into(self) -> Result<LocalPackage, Self::Error> {
         Ok(LocalPackage {
@@ -259,14 +232,8 @@ impl TryInto<LocalPackage> for GetPackage {
                 version: self.version,
                 description: self.description,
             },
-            remove: match serde_json::from_str(&self.remove_instructions) {
-                Ok(result) => result,
-                Err(error) => return Err(format!("Could not parse remove instructions:\n{error}")),
-            },
-            dependencies: match serde_json::from_str(&self.dependencies) {
-                Ok(result) => result,
-                Err(error) => return Err(format!("Could not parse dependencies:\n{error}")),
-            },
+            remove: serde_json::from_str(&self.remove_instructions)?,
+            dependencies: serde_json::from_str(&self.dependencies)?,
         })
     }
 }

--- a/src/db/errors.rs
+++ b/src/db/errors.rs
@@ -1,30 +1,13 @@
+use thiserror::Error;
+
 use diesel::result::Error as QueryError;
-use std::fmt;
-use std::fmt::Display;
 
 /// Error for performing any package db query that involves
 /// json serialization/deserialization at any point
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum TranslatedPackageQueryError {
-    Query(QueryError),
-    Json(serde_json::Error),
-}
-impl From<QueryError> for TranslatedPackageQueryError {
-    fn from(other: QueryError) -> Self {
-        TranslatedPackageQueryError::Query(other)
-    }
-}
-impl From<serde_json::Error> for TranslatedPackageQueryError {
-    fn from(other: serde_json::Error) -> Self {
-        TranslatedPackageQueryError::Json(other)
-    }
-}
-
-impl Display for TranslatedPackageQueryError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TranslatedPackageQueryError::Query(error) => write!(f, "{error}"),
-            TranslatedPackageQueryError::Json(error) => write!(f, "{error}"),
-        }
-    }
+    #[error("A query error has occured: {0}")]
+    Query(#[from] QueryError),
+    #[error("A json serialization error has occured: {0}")]
+    Json(#[from] serde_json::Error),
 }

--- a/src/db/errors.rs
+++ b/src/db/errors.rs
@@ -1,0 +1,30 @@
+use diesel::result::Error as QueryError;
+use std::fmt;
+use std::fmt::Display;
+
+/// Error for performing any package db query that involves
+/// json serialization/deserialization at any point
+#[derive(Debug)]
+pub enum TranslatedPackageQueryError {
+    Query(QueryError),
+    Json(serde_json::Error),
+}
+impl From<QueryError> for TranslatedPackageQueryError {
+    fn from(other: QueryError) -> Self {
+        TranslatedPackageQueryError::Query(other)
+    }
+}
+impl From<serde_json::Error> for TranslatedPackageQueryError {
+    fn from(other: serde_json::Error) -> Self {
+        TranslatedPackageQueryError::Json(other)
+    }
+}
+
+impl Display for TranslatedPackageQueryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TranslatedPackageQueryError::Query(error) => write!(f, "{error}"),
+            TranslatedPackageQueryError::Json(error) => write!(f, "{error}"),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,19 @@ fn main() {
 
     const CONFIG_PATH: &str = "/etc/japm/config.json";
 
-    if let Err(error) = Config::create_default_config_if_necessary(CONFIG_PATH) {
-        error!("Could not create default config if necessary:\n{error}");
-        exit(-1);
+    match Config::create_default_config_if_necessary(CONFIG_PATH) {
+        Ok(created) => {
+            if created {
+                if let Err(error) = Config::write_default_config(CONFIG_PATH) {
+                    error!("Could not write default config:\n{error}");
+                    exit(-1);
+                }
+            }
+        },
+        Err(error) => {
+            error!("Could not create default config if necessary:\n{error}");
+            exit(-1);
+        }
     }
 
     let config = match Config::from_file(CONFIG_PATH) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,14 +66,18 @@ fn main() {
     const CONFIG_PATH: &str = "/etc/japm/config.json";
 
     if let Err(error) = Config::create_default_config_if_necessary(CONFIG_PATH) {
-        error!("Could not create defaul config if necessary:\n{error}");
+        error!("Could not create default config if necessary:\n{error}");
         exit(-1);
     }
 
     let config = match Config::from_file(CONFIG_PATH) {
         Ok(config) => config,
         Err(error) => {
-            log::error!("Error while attempting to load config:\n{error}");
+            match error {
+                config::Error::IO(error) => error!("Could not parse config due to an IO error: {error}"),
+                config::Error::Json(error) => error!("Could not parse config due to a json eror: {error}"),
+                config::Error::Syntax(error_message) => error!("Could not parse config due to invalid structure/parameters: {error_message}"),
+            }
             exit(-1);
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,9 @@ fn main() {
                 reinstall,
                 packages,
             } => {
+                // Depending on the error of the package_finder install_packages returns different Result types
+                // This makes it hard to call both of these functions in a non boilerplate way. This seems like
+                // the one that less code uses
                 if from_file {
                     commands::install_packages(
                         packages,
@@ -104,8 +107,8 @@ fn main() {
                 trace!("Performing actions:\n{actions:#?}");
                 for action in actions {
                     trace!("Commiting action {action}");
-                    if let Err(error_message) = action.commit(&mut db) {
-                        error!("Could not commit action:\n{error_message}");
+                    if let Err(error) = action.commit(&mut db) {
+                        error!("Could not commit action:\n{error}");
                     } else {
                         trace!("Commited action");
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,8 @@ fn main() {
             } => {
                 // Depending on the error of the package_finder install_packages returns different Result types
                 // This makes it hard to call both of these functions in a non boilerplate way. This seems like
-                // the one that less code uses
+                // the one that less code uses. Altough it does get rid of the error itself and just gets it's string
+                // version to print out later. This can be an issue for future implementations.
                 if from_file {
                     commands::install_packages(
                         packages,
@@ -129,13 +130,13 @@ fn get_config() -> Config {
         Ok(created) => {
             if created {
                 if let Err(error) = Config::write_default_config(CONFIG_PATH) {
-                    error!("Could not write default config:\n{error}");
+                    error!("Could not write default config: {error}");
                     exit(-1);
                 }
             }
         }
         Err(error) => {
-            error!("Could not create default config if necessary:\n{error}");
+            error!("Could not create default config if necessary: {error}");
             exit(-1);
         }
     }
@@ -143,17 +144,7 @@ fn get_config() -> Config {
     match Config::from_file(CONFIG_PATH) {
         Ok(config) => config,
         Err(error) => {
-            match error {
-                config::Error::IO(error) => {
-                    error!("Could not parse config due to an IO error: {error}")
-                }
-                config::Error::Json(error) => {
-                    error!("Could not parse config due to a json eror: {error}")
-                }
-                config::Error::Syntax(error_message) => error!(
-                    "Could not parse config due to invalid structure/parameters: {error_message}"
-                ),
-            }
+            error!("Could not get config: {error}");
             exit(-1);
         }
     }
@@ -165,14 +156,14 @@ fn get_db() -> SqlitePackagesDb {
             let mut db = match SqlitePackagesDb::new() {
                 Ok(db) => db,
                 Err(error) => {
-                    error!("Could not connect to database:\n{error}");
+                    error!("Could not connect to the database: {error}");
                     exit(-1);
                 }
             };
 
             if created {
                 if let Err(error) = db.initialize_database() {
-                    error!("Could not initialize database:\n{error}");
+                    error!("Could not initialize database: {error}");
                     exit(-1);
                 }
             }
@@ -180,7 +171,7 @@ fn get_db() -> SqlitePackagesDb {
             db
         }
         Err(error) => {
-            error!("Could not create db file if necessary:\n{error}");
+            error!("Could not create db file if necessary: {error}");
             exit(-1);
         }
     }

--- a/src/package.rs
+++ b/src/package.rs
@@ -35,10 +35,7 @@ pub struct RemoteFile {
 }
 
 impl RemotePackage {
-    pub fn from_json(json: &str) -> Result<RemotePackage, String> {
-        match serde_json::from_str(json) {
-            Ok(package) => Ok(package),
-            Err(error) => Err(format!("Error parsing json:\n{error}")),
-        }
+    pub fn from_json(json: &str) -> Result<RemotePackage, serde_json::Error> {
+        serde_json::from_str(json)
     }
 }

--- a/src/package_finders/from_file.rs
+++ b/src/package_finders/from_file.rs
@@ -1,20 +1,32 @@
-use std::fs;
+use std::{fs, io};
+
+use thiserror::Error;
 
 use crate::commands::PackageFinder;
 use crate::package::RemotePackage;
 
 pub struct FromFilePackageFinder;
+#[derive(Error, Debug)]
+pub enum PackageFindError {
+    #[error("An IO error has occured: {0}")]
+    IO(#[from] io::Error),
+    #[error("A json error has occured: {0}")]
+    Json(#[from] serde_json::Error),
+}
 
 impl PackageFinder for FromFilePackageFinder {
-    fn find_package(&self, package_name: &str) -> Result<RemotePackage, String> {
+    type Error = PackageFindError;
+    fn find_package(&self, package_name: &str) -> Result<Option<RemotePackage>, Self::Error> {
         let mut path: String = String::from(package_name);
         if !path.ends_with(".json") {
             path.push_str(".json");
         }
 
-        match fs::read_to_string(path) {
-            Ok(json_content) => Ok(RemotePackage::from_json(&json_content)?),
-            Err(error) => Err(format!("Error reading package file:\n{error}")),
+        if fs::metadata(&path).is_err() {
+            return Ok(None);
         }
+
+        let json_content = fs::read_to_string(path)?;
+        Ok(Some(RemotePackage::from_json(&json_content)?))
     }
 }

--- a/src/test_helpers/mock_db.rs
+++ b/src/test_helpers/mock_db.rs
@@ -14,6 +14,10 @@ impl MockPackagesDb {
 }
 
 impl PackagesDb for MockPackagesDb {
+    type AddError = String;
+    type RemoveError = String;
+    type GetError = String;
+
     fn add_package(&mut self, package: &RemotePackage) -> Result<(), String> {
         let local_packge = LocalPackage {
             package_data: package.package_data.clone(),
@@ -40,16 +44,16 @@ impl PackagesDb for MockPackagesDb {
         }
     }
 
-    fn get_package(&mut self, package_name: &str) -> Result<LocalPackage, String> {
+    fn get_package(&mut self, package_name: &str) -> Result<Option<LocalPackage>, String> {
         let package = self
             .installed_packges
             .iter()
             .find(|p| p.package_data.name == package_name);
 
         if let Some(package) = package {
-            Ok(package.clone())
+            Ok(Some(package.clone()))
         } else {
-            Err(String::from("Package not found"))
+            Ok(None)
         }
     }
 

--- a/src/test_helpers/mod.rs
+++ b/src/test_helpers/mod.rs
@@ -1,0 +1,3 @@
+pub use mock_db::MockPackagesDb;
+
+pub mod mock_db;


### PR DESCRIPTION
Migrated most of the functions to use some sort of type errors, as most just used strings. When something failed the program just returned a borderline stack trace of all the functions failing and appending their purpose to the error string.

Errors are now made with the `thiserror` crate to avoid boilerplate, and should continue to be made like that.

Overall this made things a lot more cleaner and error prone with some small exceptions like the boilerplate in main to handle the ability to install packages with multiple package search options.